### PR TITLE
COMMONS-24 Avoid using OCL pivot.

### DIFF
--- a/de.uka.ipd.sdq.identifier/model/identifier.ecore
+++ b/de.uka.ipd.sdq.identifier/model/identifier.ecore
@@ -5,15 +5,16 @@
     <details key="documentation" value="&lt;p>&#xA;Provides a package for uniquely identifiable elements&#xA;&lt;/p>"/>
   </eAnnotations>
   <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore">
-    <details key="invocationDelegates" value="http://www.eclipse.org/emf/2002/Ecore/OCL/Pivot"/>
-    <details key="settingDelegates" value="http://www.eclipse.org/emf/2002/Ecore/OCL/Pivot"/>
-    <details key="validationDelegates" value="http://www.eclipse.org/emf/2002/Ecore/OCL/Pivot"/>
+    <details key="invocationDelegates" value="http://www.eclipse.org/emf/2002/Ecore/OCL"/>
+    <details key="settingDelegates" value="http://www.eclipse.org/emf/2002/Ecore/OCL"/>
+    <details key="validationDelegates" value="http://www.eclipse.org/emf/2002/Ecore/OCL"/>
+    
   </eAnnotations>
   <eClassifiers xsi:type="ecore:EClass" name="Identifier" abstract="true">
     <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
       <details key="documentation" value="&lt;p>&#xA;Inherit from this entity to make an element uniquely identifiable.&lt;br />&#xA;Identifiers&amp;nbsp;are&amp;nbsp;not&amp;nbsp;fixed&amp;nbsp;to&amp;nbsp;one&amp;nbsp;realization.&lt;br />&#xA;GUIDs&amp;nbsp;are&amp;nbsp;recommend.&amp;nbsp;GUIDs&amp;nbsp;are&amp;nbsp;described&amp;nbsp;in&amp;nbsp;their&amp;nbsp;own&amp;nbsp;model.&amp;nbsp;See&amp;nbsp;GUIDModel&amp;nbsp;(GUID.emx).&lt;br />&#xA;Identifier&amp;nbsp;implementations&amp;nbsp;can&amp;nbsp;be&amp;nbsp;found&amp;nbsp;in&amp;nbsp;external&amp;nbsp;projects&amp;nbsp;only.&#xA;&lt;/p>"/>
     </eAnnotations>
-    <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore/OCL/Pivot">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore/OCL">
       <details key="identifierIsUnique" value="Identifier.allInstances()->isUnique(p: Identifier | p.id)"/>
     </eAnnotations>
     <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore">

--- a/de.uka.ipd.sdq.identifier/src/de/uka/ipd/sdq/identifier/Identifier.java
+++ b/de.uka.ipd.sdq.identifier/src/de/uka/ipd/sdq/identifier/Identifier.java
@@ -30,7 +30,7 @@ import org.eclipse.emf.cdo.CDOObject;
  *
  * @see de.uka.ipd.sdq.identifier.IdentifierPackage#getIdentifier()
  * @model abstract="true"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore/OCL/Pivot identifierIsUnique='Identifier.allInstances()-&gt;isUnique(p: Identifier | p.id)'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore/OCL identifierIsUnique='Identifier.allInstances()-&gt;isUnique(p: Identifier | p.id)'"
  *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='identifierIsUnique'"
  * @extends CDOObject
  * @generated

--- a/de.uka.ipd.sdq.identifier/src/de/uka/ipd/sdq/identifier/impl/IdentifierPackageImpl.java
+++ b/de.uka.ipd.sdq.identifier/src/de/uka/ipd/sdq/identifier/impl/IdentifierPackageImpl.java
@@ -176,8 +176,8 @@ public class IdentifierPackageImpl extends EPackageImpl implements IdentifierPac
         // Create annotations
         // http://www.eclipse.org/emf/2002/Ecore
         createEcoreAnnotations();
-        // http://www.eclipse.org/emf/2002/Ecore/OCL/Pivot
-        createPivotAnnotations();
+        // http://www.eclipse.org/emf/2002/Ecore/OCL
+        createOCLAnnotations();
     }
 
     /**
@@ -192,9 +192,9 @@ public class IdentifierPackageImpl extends EPackageImpl implements IdentifierPac
           (this,
            source,
            new String[] {
-               "invocationDelegates", "http://www.eclipse.org/emf/2002/Ecore/OCL/Pivot",
-               "settingDelegates", "http://www.eclipse.org/emf/2002/Ecore/OCL/Pivot",
-               "validationDelegates", "http://www.eclipse.org/emf/2002/Ecore/OCL/Pivot"
+               "invocationDelegates", "http://www.eclipse.org/emf/2002/Ecore/OCL",
+               "settingDelegates", "http://www.eclipse.org/emf/2002/Ecore/OCL",
+               "validationDelegates", "http://www.eclipse.org/emf/2002/Ecore/OCL"
            });
         addAnnotation
           (identifierEClass,
@@ -205,13 +205,13 @@ public class IdentifierPackageImpl extends EPackageImpl implements IdentifierPac
     }
 
     /**
-     * Initializes the annotations for <b>http://www.eclipse.org/emf/2002/Ecore/OCL/Pivot</b>. <!--
-     * begin-user-doc --> <!-- end-user-doc -->
-     * 
+     * Initializes the annotations for <b>http://www.eclipse.org/emf/2002/Ecore/OCL</b>.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
      * @generated
      */
-    protected void createPivotAnnotations() {
-        String source = "http://www.eclipse.org/emf/2002/Ecore/OCL/Pivot";
+    protected void createOCLAnnotations() {
+        String source = "http://www.eclipse.org/emf/2002/Ecore/OCL";
         addAnnotation
           (identifierEClass,
            source,

--- a/de.uka.ipd.sdq.identifier/src/de/uka/ipd/sdq/identifier/util/IdentifierValidator.java
+++ b/de.uka.ipd.sdq.identifier/src/de/uka/ipd/sdq/identifier/util/IdentifierValidator.java
@@ -134,7 +134,7 @@ public class IdentifierValidator extends EObjectValidator {
                  (EObject)identifier,
                  diagnostics,
                  context,
-                 "http://www.eclipse.org/emf/2002/Ecore/OCL/Pivot",
+                 "http://www.eclipse.org/emf/2002/Ecore/OCL",
                  "identifierIsUnique",
                  IDENTIFIER__IDENTIFIER_IS_UNIQUE__EEXPRESSION,
                  Diagnostic.ERROR,


### PR DESCRIPTION
My first solution involved the Pivot engine. The constraints cannot be evaluated without a UI dependency (see https://www.eclipse.org/forums/index.php/t/1074724/). Therefore, I switched to another OCL engine for constraint evaluation.