### PR TITLE
Only depend on branding plugin instead of including it.

### DIFF
--- a/features/de.uka.ipd.sdq.dialogs.feature/feature.xml
+++ b/features/de.uka.ipd.sdq.dialogs.feature/feature.xml
@@ -19,17 +19,11 @@
       <import plugin="org.eclipse.ui.ide"/>
       <import plugin="org.eclipse.ui"/>
       <import plugin="org.eclipse.jface.text"/>
+      <import plugin="org.palladiosimulator.branding"/>
    </requires>
 
    <plugin
          id="de.uka.ipd.sdq.dialogs"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.palladiosimulator.branding"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/features/de.uka.ipd.sdq.errorhandling.feature/feature.xml
+++ b/features/de.uka.ipd.sdq.errorhandling.feature/feature.xml
@@ -14,17 +14,11 @@
    <requires>
       <import plugin="org.eclipse.core.runtime"/>
       <import plugin="org.eclipse.emf.ecore"/>
+      <import plugin="org.palladiosimulator.branding"/>
    </requires>
 
    <plugin
          id="de.uka.ipd.sdq.errorhandling"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.palladiosimulator.branding"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/features/de.uka.ipd.sdq.identifier.feature/feature.xml
+++ b/features/de.uka.ipd.sdq.identifier.feature/feature.xml
@@ -18,6 +18,7 @@
       <import plugin="de.uka.ipd.sdq.identifier"/>
       <import plugin="org.eclipse.emf.edit"/>
       <import plugin="org.eclipse.emf.ecore.edit"/>
+      <import plugin="org.palladiosimulator.branding"/>
    </requires>
 
    <plugin
@@ -32,13 +33,6 @@
          download-size="0"
          install-size="0"
          version="2.1.0.qualifier"
-         unpack="false"/>
-
-   <plugin
-         id="org.palladiosimulator.branding"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
          unpack="false"/>
 
 </feature>

--- a/features/de.uka.ipd.sdq.probfunction.feature/feature.xml
+++ b/features/de.uka.ipd.sdq.probfunction.feature/feature.xml
@@ -24,6 +24,7 @@
       <import plugin="org.eclipse.uml2.common.edit"/>
       <import plugin="org.eclipse.core.runtime" version="3.9.0" match="greaterOrEqual"/>
       <import plugin="org.apache.log4j" version="1.2.15" match="greaterOrEqual"/>
+      <import plugin="org.palladiosimulator.branding"/>
    </requires>
 
    <plugin
@@ -42,13 +43,6 @@
 
    <plugin
          id="de.uka.ipd.sdq.probfunction.math"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.palladiosimulator.branding"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/features/de.uka.ipd.sdq.statistics.feature/feature.xml
+++ b/features/de.uka.ipd.sdq.statistics.feature/feature.xml
@@ -16,17 +16,11 @@ estimators, confidence estimators and indepence tests.
       <import plugin="org.eclipse.core.runtime"/>
       <import plugin="org.apache.log4j" version="1.2.13" match="greaterOrEqual"/>
       <import plugin="de.uka.ipd.sdq.probfunction.math" version="2.0.0" match="greaterOrEqual"/>
+      <import plugin="org.palladiosimulator.branding"/>
    </requires>
 
    <plugin
          id="de.uka.ipd.sdq.statistics"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.palladiosimulator.branding"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/features/de.uka.ipd.sdq.stoex.feature/feature.xml
+++ b/features/de.uka.ipd.sdq.stoex.feature/feature.xml
@@ -23,6 +23,7 @@
       <import plugin="de.uka.ipd.sdq.units.edit"/>
       <import plugin="org.eclipse.emf.ecore.edit"/>
       <import plugin="org.eclipse.uml2.common.edit"/>
+      <import plugin="org.palladiosimulator.branding"/>
    </requires>
 
    <plugin
@@ -37,13 +38,6 @@
          download-size="0"
          install-size="0"
          version="2.2.0.qualifier"
-         unpack="false"/>
-
-   <plugin
-         id="org.palladiosimulator.branding"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
          unpack="false"/>
 
 </feature>

--- a/features/de.uka.ipd.sdq.units.feature/feature.xml
+++ b/features/de.uka.ipd.sdq.units.feature/feature.xml
@@ -23,6 +23,7 @@
       <import plugin="org.eclipse.emf.ecore.xmi"/>
       <import plugin="org.eclipse.emf.edit.ui"/>
       <import plugin="org.eclipse.ui.ide"/>
+      <import plugin="org.palladiosimulator.branding"/>
    </requires>
 
    <plugin
@@ -44,13 +45,6 @@
          download-size="0"
          install-size="0"
          version="2.1.1.qualifier"
-         unpack="false"/>
-
-   <plugin
-         id="org.palladiosimulator.branding"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
          unpack="false"/>
 
 </feature>

--- a/features/org.palladiosimulator.commons.feature/feature.xml
+++ b/features/org.palladiosimulator.commons.feature/feature.xml
@@ -45,17 +45,11 @@
       <import plugin="org.eclipse.emf.edit.ui"/>
       <import plugin="org.eclipse.core.runtime" version="3.10.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.core.resources"/>
+      <import plugin="org.palladiosimulator.branding"/>
    </requires>
 
    <plugin
          id="org.palladiosimulator.commons"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.palladiosimulator.branding"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/features/org.palladiosimulator.commons.stoex.feature/feature.xml
+++ b/features/org.palladiosimulator.commons.stoex.feature/feature.xml
@@ -14,6 +14,7 @@
    <requires>
       <import feature="org.eclipse.xtext.sdk" version="2.8.1.v201503230617"/>
       <import feature="org.eclipse.xtend.sdk" version="2.8.1.v201503230617"/>
+      <import plugin="org.palladiosimulator.branding"/>
    </requires>
 
    <plugin
@@ -46,13 +47,6 @@
 
    <plugin
          id="org.palladiosimulator.commons.xtexttools"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.palladiosimulator.branding"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/features/org.palladiosimulator.commons.stoex.sdk/feature.xml
+++ b/features/org.palladiosimulator.commons.stoex.sdk/feature.xml
@@ -7,6 +7,10 @@
       license-feature="org.palladiosimulator.license"
       license-feature-version="1.0.0">
 
+   <requires>
+      <import plugin="org.palladiosimulator.branding"/>
+   </requires>
+
    <plugin
          id="org.palladiosimulator.commons.stoex"
          download-size="0"
@@ -23,13 +27,6 @@
 
    <plugin
          id="org.palladiosimulator.commons.stoex.adapter"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.palladiosimulator.branding"
          download-size="0"
          install-size="0"
          version="0.0.0"


### PR DESCRIPTION
Inclusion of the branding plugin in a feature is not useful because we provide the plugin via a central update site. Therefore, depending on the plugin is sufficient.