### PR TITLE
COMMONS-40 Create specific samples instead of generic samples for iPMFs

### DIFF
--- a/bundles/de.uka.ipd.sdq.probfunction.math/META-INF/MANIFEST.MF
+++ b/bundles/de.uka.ipd.sdq.probfunction.math/META-INF/MANIFEST.MF
@@ -19,3 +19,4 @@ Require-Bundle: de.uka.ipd.sdq.probfunction;bundle-version="2.1.0",
  org.apache.log4j;bundle-version="1.2.15"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
+Automatic-Module-Name: de.uka.ipd.sdq.probfunction.math

--- a/tests/de.uka.ipd.sdq.probfunction.math.tests/META-INF/MANIFEST.MF
+++ b/tests/de.uka.ipd.sdq.probfunction.math.tests/META-INF/MANIFEST.MF
@@ -8,3 +8,9 @@ Require-Bundle: de.uka.ipd.sdq.probfunction.math;bundle-version="2.0.0",
  de.uka.ipd.sdq.probfunction;bundle-version="2.1.0",
  org.junit;bundle-version="4.11.0"
 Bundle-Vendor: sdq.ipd.uka.de
+Import-Package: net.bytebuddy.dynamic.loading;version="1.9.0",
+ org.mockito;version="2.23.0",
+ org.mockito.mock;version="2.23.0",
+ org.mockito.stubbing;version="2.23.0",
+ org.objenesis;version="2.6.0"
+Automatic-Module-Name: de.uka.ipd.sdq.probfunction.math.tests

--- a/tests/de.uka.ipd.sdq.probfunction.math.tests/src/de/uka/ipd/sdq/probfunction/math/test/ProbabilityFunctionFactoryTest.java
+++ b/tests/de.uka.ipd.sdq.probfunction.math.tests/src/de/uka/ipd/sdq/probfunction/math/test/ProbabilityFunctionFactoryTest.java
@@ -7,14 +7,16 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import junit.framework.JUnit4TestAdapter;
-
 import org.eclipse.emf.common.util.EList;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
+import de.uka.ipd.sdq.probfunction.BoolSample;
 import de.uka.ipd.sdq.probfunction.BoxedPDF;
 import de.uka.ipd.sdq.probfunction.ContinuousSample;
+import de.uka.ipd.sdq.probfunction.DoubleSample;
+import de.uka.ipd.sdq.probfunction.IntSample;
 import de.uka.ipd.sdq.probfunction.ProbabilityMassFunction;
 import de.uka.ipd.sdq.probfunction.ProbfunctionFactory;
 import de.uka.ipd.sdq.probfunction.Sample;
@@ -39,6 +41,7 @@ import de.uka.ipd.sdq.probfunction.math.exception.UnitNameNotSetException;
 import de.uka.ipd.sdq.probfunction.math.exception.UnitNotSetException;
 import de.uka.ipd.sdq.probfunction.math.exception.UnknownPDFTypeException;
 import de.uka.ipd.sdq.probfunction.math.impl.ProbabilityFunctionFactoryImpl;
+import junit.framework.JUnit4TestAdapter;
 
 /**
  * @author Ihssane
@@ -149,6 +152,54 @@ public class ProbabilityFunctionFactoryTest {
 
         // assertTrue(iProbFunc.getUnit().getUnitName().equals("sec"));
         assertTrue(iProbFunc.hasOrderedDomain());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void iPMFToPMFForIntSamples() {
+        var iPMF = pfFactory.createPMFFromMeasurements(new Integer[] { 0, 1, 2 }, null, false);
+        var pmf = pfFactory.transformToModelPMF(iPMF);
+        assertTrue(pmf.getSamples()
+            .stream()
+            .allMatch(IntSample.class::isInstance));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void iPMFToPMFForDoubleSamples() {
+        var iPMF = pfFactory.createPMFFromMeasurements(new Double[] { 0.0, 1.1, 2.2 }, 0.01, null, false);
+        var pmf = pfFactory.transformToModelPMF(iPMF);
+        assertTrue(pmf.getSamples()
+            .stream()
+            .allMatch(DoubleSample.class::isInstance));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void iPMFToPMFForBooleanSamples() {
+        var iPMF = pfFactory.createPMFFromMeasurements(new Boolean[] { true, false, true }, null, false);
+        var pmf = pfFactory.transformToModelPMF(iPMF);
+        assertTrue(pmf.getSamples()
+            .stream()
+            .allMatch(BoolSample.class::isInstance));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void iPMFToPMFForMixedSamples() {
+        var iPMF = pfFactory.createPMFFromMeasurements(new Double[] { 0.1, 1.1, 2.2 }, 0.01, null, false);
+        var newSamples = new ArrayList<>(iPMF.getSamples());
+        var intSample = pfFactory.createSample(1, 0.1);
+        newSamples.add(intSample);
+
+        var ipmfMock = Mockito.mock(IProbabilityMassFunction.class);
+        Mockito.when(ipmfMock.getSamples())
+            .thenReturn(newSamples);
+        var pmf = pfFactory.transformToModelPMF(ipmfMock);
+
+        assertTrue(pmf.getSamples()
+            .stream()
+            .allMatch(s -> s.getClass() == de.uka.ipd.sdq.probfunction.impl.SampleImpl.class));
     }
 
     @Test


### PR DESCRIPTION
This PR addresses [COMMONS-40](https://palladio-simulator.atlassian.net/browse/COMMONS-40).

We identified the location that produces generic samples for PMFs and inserted logic to produce the most concrete subtype of samples based on the value type. This is some sort of hacky solution because it would be better to remember the type of samples in the IProbabilityMassFunction and recreate these particular types later. However, this requires changes of APIs that are used in various places.

We are not sure if this is the only location which produces these generic samples but at least it fixes the particular error reported in the issue.