### PR TITLE
NamespaceReference should return NamespaceReference

### DIFF
--- a/bundles/org.palladiosimulator.commons.stoex/src/org/palladiosimulator/commons/stoex/Stoex.xtext
+++ b/bundles/org.palladiosimulator.commons.stoex/src/org/palladiosimulator/commons/stoex/Stoex.xtext
@@ -125,7 +125,7 @@ AbstractNamedReference:
     VariableReference | NamespaceReference
 ;
 
-NamespaceReference returns AbstractNamedReference:
+NamespaceReference:
     {NamespaceReference} referenceName=ID '.' innerReference_NamespaceReference=AbstractNamedReference
 ;
 


### PR DESCRIPTION
There is no advantage in having the rule return the abstract type. On the contrary, TPM relies on NamespaceReferences to have an inner reference.