### PR TITLE
Add DatabindingLaunchConfigurationTab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ bin/
 *.jar
 xtend-gen/
 target/
-*.xml_gen

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin/
 *.jar
 xtend-gen/
 target/
+*.xml_gen

--- a/bundles/org.palladiosimulator.commons.ui/.classpath
+++ b/bundles/org.palladiosimulator.commons.ui/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/bundles/org.palladiosimulator.commons.ui/.project
+++ b/bundles/org.palladiosimulator.commons.ui/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.palladiosimulator.commons.ui</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/org.palladiosimulator.commons.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.palladiosimulator.commons.ui/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=11

--- a/bundles/org.palladiosimulator.commons.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.commons.ui/META-INF/MANIFEST.MF
@@ -1,0 +1,13 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Palladio Common UI Components
+Bundle-SymbolicName: org.palladiosimulator.commons.ui
+Bundle-Version: 1.0.0.qualifier
+Automatic-Module-Name: org.palladiosimulator.commons.ui
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Export-Package: org.palladiosimulator.commons.ui.launch
+Require-Bundle: org.eclipse.debug.ui,
+ org.eclipse.swt,
+ org.eclipse.core.databinding.observable,
+ org.eclipse.core.databinding
+Import-Package: org.eclipse.core.runtime

--- a/bundles/org.palladiosimulator.commons.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.commons.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Palladio Common UI Components
-Bundle-SymbolicName: org.palladiosimulator.commons.ui
+Bundle-SymbolicName: org.palladiosimulator.commons.ui;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: org.palladiosimulator.commons.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/bundles/org.palladiosimulator.commons.ui/build.properties
+++ b/bundles/org.palladiosimulator.commons.ui/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/bundles/org.palladiosimulator.commons.ui/build.properties
+++ b/bundles/org.palladiosimulator.commons.ui/build.properties
@@ -1,4 +1,5 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
-               .
+               .,\
+               plugin.xml

--- a/bundles/org.palladiosimulator.commons.ui/plugin.xml
+++ b/bundles/org.palladiosimulator.commons.ui/plugin.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+
+</plugin>

--- a/bundles/org.palladiosimulator.commons.ui/src/org/palladiosimulator/commons/ui/launch/AbstractDataBindingLaunchConfigurationTab.java
+++ b/bundles/org.palladiosimulator.commons.ui/src/org/palladiosimulator/commons/ui/launch/AbstractDataBindingLaunchConfigurationTab.java
@@ -38,6 +38,7 @@ public abstract class AbstractDataBindingLaunchConfigurationTab extends Abstract
 
     @Override
     public final void createControl(Composite parent) {
+        setDirty(false);
         getLaunchConfigAdapter();
         
         assert dbc != null;

--- a/bundles/org.palladiosimulator.commons.ui/src/org/palladiosimulator/commons/ui/launch/AbstractDataBindingLaunchConfigurationTab.java
+++ b/bundles/org.palladiosimulator.commons.ui/src/org/palladiosimulator/commons/ui/launch/AbstractDataBindingLaunchConfigurationTab.java
@@ -14,9 +14,9 @@ import org.eclipse.swt.widgets.Composite;
  * same validation logic multiple times.
  * 
  * Instead of implementing
- * {@code AbstractLaunchConfigurationTab#initializeFrom(ILaunchConfiguration)},
- * {@code AbstractLaunchConfigurationTab#performApply(ILaunchConfigurationWorkingCopy)} and
- * {@code AbstractLaunchConfigurationTab#setDefaults(ILaunchConfigurationWorkingCopy)}, registry the
+ * {@link AbstractLaunchConfigurationTab#initializeFrom(ILaunchConfiguration)},
+ * {@link AbstractLaunchConfigurationTab#performApply(ILaunchConfigurationWorkingCopy)} and
+ * {@link AbstractLaunchConfigurationTab#setDefaults(ILaunchConfigurationWorkingCopy)}, registry the
  * required bindings, already providing sensible defaults through
  * {@link #registerDataBindings(ObservableLaunchConfigurationAttributeFactory)}.
  * 

--- a/bundles/org.palladiosimulator.commons.ui/src/org/palladiosimulator/commons/ui/launch/AbstractDataBindingLaunchConfigurationTab.java
+++ b/bundles/org.palladiosimulator.commons.ui/src/org/palladiosimulator/commons/ui/launch/AbstractDataBindingLaunchConfigurationTab.java
@@ -1,0 +1,83 @@
+package org.palladiosimulator.commons.ui.launch;
+
+import org.eclipse.core.databinding.DataBindingContext;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.ui.AbstractLaunchConfigurationTab;
+import org.eclipse.swt.widgets.Composite;
+
+/**
+ * This abstract super class integrates the observable launch configuration adapter with the launch
+ * configuration tab hierarchy.
+ * 
+ * It simplifies creating launch configuration dialogs, as it relieves you from implementing the
+ * same validation logic multiple times.
+ * 
+ * Instead of implementing
+ * {@code AbstractLaunchConfigurationTab#initializeFrom(ILaunchConfiguration)},
+ * {@code AbstractLaunchConfigurationTab#performApply(ILaunchConfigurationWorkingCopy)} and
+ * {@code AbstractLaunchConfigurationTab#setDefaults(ILaunchConfigurationWorkingCopy)}, registry the
+ * required bindings, already providing sensible defaults through
+ * {@link #registerDataBindings(ObservableLaunchConfigurationAttributeFactory)}.
+ * 
+ * Please note, that due to the way, the launch configurations work, the data bindings need to be
+ * registered before the controls are created. To bind your UI elements to launch configuration
+ * properties, please store the observable value references as class attributes.
+ * 
+ * @author Sebastian Krach
+ *
+ */
+public abstract class AbstractDataBindingLaunchConfigurationTab extends AbstractLaunchConfigurationTab {
+
+    private ObservableLaunchConfigurationAdapter launchConfigAdapter;
+    private DataBindingContext dbc;
+
+    abstract protected void registerDataBindings(ObservableLaunchConfigurationAttributeFactory attributeFactory, DataBindingContext bindingContext);
+
+    abstract protected void createControlInternal(Composite parent, DataBindingContext bindingContext);
+
+    @Override
+    public final void createControl(Composite parent) {
+        getLaunchConfigAdapter();
+        
+        assert dbc != null;
+        createControlInternal(parent, dbc);
+    }
+
+    @Override
+    public void initializeFrom(final ILaunchConfiguration configuration) {
+        getLaunchConfigAdapter().initializeFrom(configuration);
+    }
+
+    @Override
+    public void performApply(final ILaunchConfigurationWorkingCopy configuration) {
+        getLaunchConfigAdapter().performApply(configuration);
+    }
+
+    @Override
+    public void setDefaults(final ILaunchConfigurationWorkingCopy configuration) {
+        getLaunchConfigAdapter().setDefaults(configuration);
+    }
+
+    @Override
+    public void activated(final ILaunchConfigurationWorkingCopy workingCopy) {
+    }
+
+    @Override
+    public void deactivated(final ILaunchConfigurationWorkingCopy workingCopy) {
+    }
+
+    private ObservableLaunchConfigurationAdapter getLaunchConfigAdapter() {
+        if (launchConfigAdapter == null) {
+            launchConfigAdapter = new ObservableLaunchConfigurationAdapter();
+            dbc = new DataBindingContext();
+            registerDataBindings(launchConfigAdapter, dbc);
+            launchConfigAdapter.notifyWhenDirty(() -> {
+                setDirty(true);
+                updateLaunchConfigurationDialog();
+            });
+        }
+        return launchConfigAdapter;
+    }
+
+}

--- a/bundles/org.palladiosimulator.commons.ui/src/org/palladiosimulator/commons/ui/launch/ObservableLaunchConfigurationAdapter.java
+++ b/bundles/org.palladiosimulator.commons.ui/src/org/palladiosimulator/commons/ui/launch/ObservableLaunchConfigurationAdapter.java
@@ -11,20 +11,21 @@ import org.eclipse.core.databinding.observable.value.WritableValue;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.ui.AbstractLaunchConfigurationTab;
 
 /**
  * This class serves as generic bridge between Eclipse Launch Configurations and the Eclipse databinding framework.
  * 
- * For detaiuls on its usage, please see {@link ObservableLaunchConfigurationAttributeFactory}.
+ * For details on its usage, please see {@link ObservableLaunchConfigurationAttributeFactory}.
  * 
  * @author Sebastian Krach
  *
  */
 public class ObservableLaunchConfigurationAdapter implements ObservableLaunchConfigurationAttributeFactory {
-    protected Map<String, Consumer<ILaunchConfigurationWorkingCopy>> lcUpdates = new HashMap<>();
-    protected Map<String, Consumer<ILaunchConfiguration>> mUpdates = new HashMap<>();
-    protected Map<String, Consumer<ILaunchConfigurationWorkingCopy>> defaults = new HashMap<>();
-    protected Map<String, IObservableValue<?>> observables = new HashMap<>();
+    protected final Map<String, Consumer<ILaunchConfigurationWorkingCopy>> lcUpdates = new HashMap<>();
+    protected final Map<String, Consumer<ILaunchConfiguration>> mUpdates = new HashMap<>();
+    protected final Map<String, Consumer<ILaunchConfigurationWorkingCopy>> defaults = new HashMap<>();
+    protected final Map<String, IObservableValue<?>> observables = new HashMap<>();
     private ISideEffect dirtyNotificationEffect;
     private Runnable dirtyNotification;
     private volatile boolean isInitialization = false;
@@ -33,6 +34,11 @@ public class ObservableLaunchConfigurationAdapter implements ObservableLaunchCon
         this.dirtyNotification = dirtyNotification;
     }
 
+    /**
+     * Initialize values from {@link ILaunchConfiguration}.
+     * 
+     * @see AbstractLaunchConfigurationTab#initializeFrom(ILaunchConfiguration)
+     */
     public void initializeFrom(final ILaunchConfiguration configuration) {
         if (dirtyNotificationEffect != null) {
             dirtyNotificationEffect.dispose();
@@ -50,11 +56,22 @@ public class ObservableLaunchConfigurationAdapter implements ObservableLaunchCon
         isInitialization = false;
     }
 
+    /**
+     * Apply changes to {@link ILaunchConfigurationWorkingCopy}
+     * 
+     * @see AbstractLaunchConfigurationTab#performApply(ILaunchConfigurationWorkingCopy)
+     * 
+     */
     public void performApply(ILaunchConfigurationWorkingCopy workingCopy) {
         lcUpdates.values()
             .forEach(c -> c.accept(workingCopy));
     }
 
+    /**
+     * Initialize launch configuration with defaults.
+     * 
+     * @see AbstractLaunchConfigurationTab#setDefaults(ILaunchConfigurationWorkingCopy)
+     */
     public void setDefaults(final ILaunchConfigurationWorkingCopy configuration) {
         defaults.values()
             .forEach(c -> c.accept(configuration));

--- a/bundles/org.palladiosimulator.commons.ui/src/org/palladiosimulator/commons/ui/launch/ObservableLaunchConfigurationAdapter.java
+++ b/bundles/org.palladiosimulator.commons.ui/src/org/palladiosimulator/commons/ui/launch/ObservableLaunchConfigurationAdapter.java
@@ -1,0 +1,119 @@
+package org.palladiosimulator.commons.ui.launch;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.eclipse.core.databinding.observable.sideeffect.ISideEffect;
+import org.eclipse.core.databinding.observable.value.IObservableValue;
+import org.eclipse.core.databinding.observable.value.WritableValue;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+
+/**
+ * This class serves as generic bridge between Eclipse Launch Configurations and the Eclipse databinding framework.
+ * 
+ * For detaiuls on its usage, please see {@link ObservableLaunchConfigurationAttributeFactory}.
+ * 
+ * @author Sebastian Krach
+ *
+ */
+public class ObservableLaunchConfigurationAdapter implements ObservableLaunchConfigurationAttributeFactory {
+    protected Map<String, Consumer<ILaunchConfigurationWorkingCopy>> lcUpdates = new HashMap<>();
+    protected Map<String, Consumer<ILaunchConfiguration>> mUpdates = new HashMap<>();
+    protected Map<String, Consumer<ILaunchConfigurationWorkingCopy>> defaults = new HashMap<>();
+    protected Map<String, IObservableValue<?>> observables = new HashMap<>();
+    private ISideEffect dirtyNotificationEffect;
+    private Runnable dirtyNotification;
+
+    public void notifyWhenDirty(Runnable dirtyNotification) {
+        this.dirtyNotification = dirtyNotification;
+    }
+
+    public void initializeFrom(final ILaunchConfiguration configuration) {
+        if (dirtyNotificationEffect != null) {
+            dirtyNotificationEffect.dispose();
+        }
+        mUpdates.values()
+            .forEach(c -> c.accept(configuration));
+        dirtyNotificationEffect = ISideEffect.create(() -> {
+            observables.values()
+                .forEach(IObservableValue::getValue);
+            dirtyNotification.run();
+        });
+    }
+
+    public void performApply(ILaunchConfigurationWorkingCopy workingCopy) {
+        lcUpdates.values()
+            .forEach(c -> c.accept(workingCopy));
+    }
+
+    public void setDefaults(final ILaunchConfigurationWorkingCopy configuration) {
+        defaults.values()
+            .forEach(c -> c.accept(configuration));
+    }
+
+    @Override
+    public IObservableValue<String> createStringAttribute(String id, String defaultValue) {
+        // We do have to duplicate code here, to guarantee statical correctness (get/setAttribute is
+        // references in the string version)
+        return createObservableAttribute(id, defaultValue, ILaunchConfigurationWorkingCopy::setAttribute,
+                ILaunchConfiguration::getAttribute);
+    }
+
+    @Override
+    public IObservableValue<Integer> createIntegerAttribute(String id, int defaultValue) {
+        // We do have to duplicate code here, to guarantee statical correctness (get/setAttribute is
+        // references in the int version)
+        return createObservableAttribute(id, defaultValue, ILaunchConfigurationWorkingCopy::setAttribute,
+                ILaunchConfiguration::getAttribute);
+    }
+
+    @Override
+    public IObservableValue<Boolean> createBooleanAttribute(String id, boolean defaultValue) {
+        // We do have to duplicate code here, to guarantee statical correctness (get/setAttribute is
+        // references in the boolean version)
+        return createObservableAttribute(id, defaultValue, ILaunchConfigurationWorkingCopy::setAttribute,
+                ILaunchConfiguration::getAttribute);
+    }
+
+    @Override
+    public <T> IObservableValue<T> createFromStringAttribute(String id, T defaultValue,
+            Function<String, T> fromLCConverter, Function<T, String> toLCConverter) {
+        AttributeSetter<T> setter = (lc, i, val) -> lc.setAttribute(i, toLCConverter.apply(val));
+        AttributeExtractor<T> getter = (lc, i, val) -> fromLCConverter
+            .apply(lc.getAttribute(i, toLCConverter.apply(val)));
+        return createObservableAttribute(id, defaultValue, setter, getter);
+    }
+
+    @Override
+    public <T> IObservableValue<T> createObservableAttribute(String id, T defaultValue, AttributeSetter<T> setter,
+            AttributeExtractor<T> getter) {
+        var result = new WritableValue<T>(defaultValue, null);
+        result.addChangeListener((ev) -> {
+            lcUpdates.put(id, wc -> setter.apply(wc, id, result.getValue()));
+        });
+        mUpdates.put(id, lc -> {
+            T value = defaultValue;
+            try {
+                value = getter.apply(lc, id, defaultValue);
+            } catch (CoreException e) {
+            }
+            result.setValue(value);
+        });
+        defaults.put(id, lc -> {
+            setter.apply(lc, id, defaultValue);
+        });
+        observables.put(id, result);
+        result.addDisposeListener(ev -> {
+            lcUpdates.remove(id);
+            mUpdates.remove(id);
+            defaults.remove(id);
+            observables.remove(id);
+        });
+        return result;
+    }
+
+}

--- a/bundles/org.palladiosimulator.commons.ui/src/org/palladiosimulator/commons/ui/launch/ObservableLaunchConfigurationAdapter.java
+++ b/bundles/org.palladiosimulator.commons.ui/src/org/palladiosimulator/commons/ui/launch/ObservableLaunchConfigurationAdapter.java
@@ -27,6 +27,7 @@ public class ObservableLaunchConfigurationAdapter implements ObservableLaunchCon
     protected Map<String, IObservableValue<?>> observables = new HashMap<>();
     private ISideEffect dirtyNotificationEffect;
     private Runnable dirtyNotification;
+    private volatile boolean isInitialization = false;
 
     public void notifyWhenDirty(Runnable dirtyNotification) {
         this.dirtyNotification = dirtyNotification;
@@ -38,11 +39,15 @@ public class ObservableLaunchConfigurationAdapter implements ObservableLaunchCon
         }
         mUpdates.values()
             .forEach(c -> c.accept(configuration));
+        isInitialization = true;
         dirtyNotificationEffect = ISideEffect.create(() -> {
             observables.values()
                 .forEach(IObservableValue::getValue);
-            dirtyNotification.run();
+            if (dirtyNotification != null && !isInitialization) {
+                dirtyNotification.run();
+            }
         });
+        isInitialization = false;
     }
 
     public void performApply(ILaunchConfigurationWorkingCopy workingCopy) {

--- a/bundles/org.palladiosimulator.commons.ui/src/org/palladiosimulator/commons/ui/launch/ObservableLaunchConfigurationAttributeFactory.java
+++ b/bundles/org.palladiosimulator.commons.ui/src/org/palladiosimulator/commons/ui/launch/ObservableLaunchConfigurationAttributeFactory.java
@@ -1,0 +1,94 @@
+package org.palladiosimulator.commons.ui.launch;
+
+import java.util.function.Function;
+
+import org.eclipse.core.databinding.observable.value.IObservableValue;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+
+/**
+ * This factory interface provides the required capabilities to define mappings between launch configuration attributes and observable variables.
+ * 
+ * It simplifies creating launch configuration dialogs, as it enables you to use eclipse databindings in your editor logic. 
+ * 
+ * @author Sebastian Krach
+ *
+ */
+public interface ObservableLaunchConfigurationAttributeFactory {
+    @FunctionalInterface
+    public static interface AttributeExtractor<T> {
+        T apply(ILaunchConfiguration launchConfig, String attributeName, T defaultValue) throws CoreException;
+    }
+
+    @FunctionalInterface
+    public static interface AttributeSetter<T> {
+        void apply(ILaunchConfigurationWorkingCopy launchConfig, String attributeName, T value);
+    }
+
+    /**
+     * Creates a new generic observable launch configuration attribute
+     * 
+     * @param <T>
+     *            the type of the observable value
+     * @param id
+     *            the id of the launch configuration attribute
+     * @param defaultValue
+     *            the default value, if the attribute is not set
+     * @param setter
+     *            the function to store an instance of the observable value in the launch
+     *            configuration object
+     * @param getter
+     *            the function to get an instance of the observable value from the launch
+     *            configuration object
+     * @return an observable value.
+     */
+    <T> IObservableValue<T> createObservableAttribute(String id, T defaultValue, AttributeSetter<T> setter,
+            AttributeExtractor<T> getter);
+
+    /**
+     * Creates new observable string attribute.
+     * 
+     * @param id
+     *            the id of the string attribute
+     * @param defaultValue
+     *            the default value
+     * @return an observable string value
+     */
+    IObservableValue<String> createStringAttribute(String id, String defaultValue);
+    
+    /**
+     * Creates new observable integer attribute.
+     * 
+     * @param id
+     *            the id of the integer attribute
+     * @param defaultValue
+     *            the default value
+     * @return an observable integer value
+     */
+    IObservableValue<Integer> createIntegerAttribute(String id, int defaultValue);
+    
+    /**
+     * Creates new observable boolean attribute.
+     * 
+     * @param id
+     *            the id of the boolean attribute
+     * @param defaultValue
+     *            the default value
+     * @return an observable boolean value
+     */
+    IObservableValue<Boolean> createBooleanAttribute(String id, boolean defaultValue);
+
+    /**
+     * Creates a new observable based on a string launch configuration attribute
+     * @param <T> the type of the observable object
+     * @param id the id of the string attribute
+     * @param defaultValue the default value
+     * @param fromLCConverter the converter function from string to the observable object type
+     * @param toLCConverter the converter function from the object type to string
+     * @return an observable value of the specified type
+     */
+    <T> IObservableValue<T> createFromStringAttribute(String id, T defaultValue, Function<String, T> fromLCConverter,
+            Function<T, String> toLCConverter);
+
+}

--- a/features/org.palladiosimulator.commons.feature/feature.xml
+++ b/features/org.palladiosimulator.commons.feature/feature.xml
@@ -43,6 +43,10 @@
          id="org.palladiosimulator.commons.stoex.sdk"
          version="0.0.0"/>
 
+<includes
+         id="org.palladiosimulator.commons.ui.feature"
+         version="0.0.0"/>
+
    <requires>
       <import plugin="org.eclipse.emf.ecore"/>
       <import plugin="org.eclipse.emf.edit"/>

--- a/features/org.palladiosimulator.commons.ui.feature/.project
+++ b/features/org.palladiosimulator.commons.ui.feature/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.palladiosimulator.commons.ui.feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/features/org.palladiosimulator.commons.ui.feature/build.properties
+++ b/features/org.palladiosimulator.commons.ui.feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/features/org.palladiosimulator.commons.ui.feature/feature.xml
+++ b/features/org.palladiosimulator.commons.ui.feature/feature.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.palladiosimulator.commons.ui.feature"
+      label="Palladio Common UI Components Feature"
+      version="1.0.0.qualifier"
+      plugin="org.palladiosimulator.branding"
+      license-feature="org.palladiosimulator.license.epl2"
+      license-feature-version="1.0.0">
+
+   <description>
+      This feature contains shared UI elements for the Palladio Simulator project.
+   </description>
+
+   <plugin
+         id="org.palladiosimulator.commons.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/releng/org.palladiosimulator.core-commons.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.core-commons.targetplatform/tp.target
@@ -42,9 +42,5 @@
 <unit id="de.itemis.xtext.antlr.feature.feature.group" version="0.0.0"/>
 <repository location="http://download.itemis.com/updates/releases/2.1.1"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-<unit id="tools.mdsd.junit5utils.feature.feature.group" version="0.0.0"/>
-<repository location="https://updatesite.mdsd.tools/library-junit5utils/releases/latest/"/>
-</location>
 </locations>
 </target>

--- a/releng/org.palladiosimulator.core-commons.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.core-commons.targetplatform/tp.target
@@ -42,5 +42,9 @@
 <unit id="de.itemis.xtext.antlr.feature.feature.group" version="0.0.0"/>
 <repository location="http://download.itemis.com/updates/releases/2.1.1"/>
 </location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+<unit id="tools.mdsd.junit5utils.feature.feature.group" version="0.0.0"/>
+<repository location="https://updatesite.mdsd.tools/library-junit5utils/releases/latest/"/>
+</location>
 </locations>
 </target>

--- a/tests/org.palladiosimulator.commons.ui.tests/.classpath
+++ b/tests/org.palladiosimulator.commons.ui.tests/.classpath
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/tests/org.palladiosimulator.commons.ui.tests/.project
+++ b/tests/org.palladiosimulator.commons.ui.tests/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.palladiosimulator.commons.ui.tests</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/tests/org.palladiosimulator.commons.ui.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/tests/org.palladiosimulator.commons.ui.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=11

--- a/tests/org.palladiosimulator.commons.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.palladiosimulator.commons.ui.tests/META-INF/MANIFEST.MF
@@ -8,5 +8,6 @@ Automatic-Module-Name: org.palladiosimulator.commons.ui.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit,
  org.junit.jupiter.api,
- tools.mdsd.junit5utils;bundle-version="0.1.0",
- org.eclipse.jface.databinding
+ tools.mdsd.junit5utils,
+ org.eclipse.jface.databinding,
+ org.eclipse.emf.common

--- a/tests/org.palladiosimulator.commons.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.palladiosimulator.commons.ui.tests/META-INF/MANIFEST.MF
@@ -1,0 +1,12 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Palladio Commons UI Tests
+Bundle-SymbolicName: org.palladiosimulator.commons.ui.tests;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Fragment-Host: org.palladiosimulator.commons.ui;bundle-version="1.0.0"
+Automatic-Module-Name: org.palladiosimulator.commons.ui.tests
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Require-Bundle: org.junit,
+ org.junit.jupiter.api,
+ tools.mdsd.junit5utils;bundle-version="0.1.0",
+ org.eclipse.jface.databinding

--- a/tests/org.palladiosimulator.commons.ui.tests/build.properties
+++ b/tests/org.palladiosimulator.commons.ui.tests/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               fragment.xml

--- a/tests/org.palladiosimulator.commons.ui.tests/fragment.xml
+++ b/tests/org.palladiosimulator.commons.ui.tests/fragment.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<fragment>
+   <extension
+         point="org.eclipse.debug.core.launchConfigurationTypes">
+      <launchConfigurationType
+            id="org.palladiosimulator.commons.ui.tests.observableLaunchType"
+            name="ObservableLaunchConfigAdapterTestConfiguration">
+      </launchConfigurationType>
+   </extension>
+
+</fragment>

--- a/tests/org.palladiosimulator.commons.ui.tests/pom.xml
+++ b/tests/org.palladiosimulator.commons.ui.tests/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.palladiosimulator.core-commons</groupId>
+    <artifactId>tests</artifactId>
+    <version>5.0.0-SNAPSHOT</version>
+    <relativePath>..\.polyglot.pom.tycho</relativePath>
+  </parent>
+  <artifactId>org.palladiosimulator.commons.ui.tests</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>eclipse-test-plugin</packaging>
+  <name>[test-bundle] Palladio Commons UI Tests</name>
+
+  <build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-surefire-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>default-test</id>
+						<configuration>
+							<useUIHarness>true</useUIHarness>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tests/org.palladiosimulator.commons.ui.tests/src/org/palladiosimulator/commons/ui/launch/DefaultRealmExtension.java
+++ b/tests/org.palladiosimulator.commons.ui.tests/src/org/palladiosimulator/commons/ui/launch/DefaultRealmExtension.java
@@ -1,0 +1,40 @@
+package org.palladiosimulator.commons.ui.launch;
+
+import org.eclipse.core.databinding.observable.Realm;
+import org.eclipse.jface.databinding.swt.DisplayRealm;
+import org.eclipse.swt.widgets.Display;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class DefaultRealmExtension implements BeforeEachCallback,
+    AfterEachCallback{
+    public static class RealmHelper extends Realm {
+        @Override
+        public boolean isCurrent() {
+            // This is not relevant
+            return true;
+        }
+        protected static Realm setDefault(Realm realm) {
+            return Realm.setDefault(realm);
+        }
+    }
+
+    private Realm previousRealm;
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        RealmHelper.setDefault(previousRealm);
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        previousRealm = Realm.getDefault();
+        
+        Display display = Display.getCurrent() != null
+                && !Display.getCurrent().isDisposed() ? Display.getCurrent()
+                : Display.getDefault();
+        
+        RealmHelper.setDefault(DisplayRealm.getRealm(display));
+    }
+}

--- a/tests/org.palladiosimulator.commons.ui.tests/src/org/palladiosimulator/commons/ui/launch/ObservableLaunchConfigurationAdapterTest.java
+++ b/tests/org.palladiosimulator.commons.ui.tests/src/org/palladiosimulator/commons/ui/launch/ObservableLaunchConfigurationAdapterTest.java
@@ -1,0 +1,67 @@
+package org.palladiosimulator.commons.ui.launch;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.CoreMatchers.*;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunchConfigurationType;
+import org.eclipse.debug.core.ILaunchManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import tools.mdsd.junit5utils.annotations.PluginTestOnly;
+
+@PluginTestOnly
+class ObservableLaunchConfigurationAdapterTest {
+    public static final String TEST_CONFIGURATION_TYPE = "org.palladiosimulator.commons.ui.tests.observableLaunchType";
+    public static final String ATTRIBUTE_1= "attribute1";
+    public static final String ATTRIBUTE_2= "attribute2";
+    public static final String ATTRIBUTE_3= "attribute3";
+    public static final String ATTRIBUTE_4= "attribute4";
+    
+    ObservableLaunchConfigurationAdapter adapter;
+    ILaunchManager manager;
+    ILaunchConfigurationType launchType;
+
+    @BeforeEach
+    void initAdapter() {
+        manager = DebugPlugin.getDefault().getLaunchManager();
+        launchType = manager.getLaunchConfigurationType(TEST_CONFIGURATION_TYPE);
+        
+        this.adapter = new ObservableLaunchConfigurationAdapter();
+    }
+
+    @Test
+    void testDefaultInitializeWrite() throws CoreException {
+        var launch = launchType.newInstance(null, "test1");
+        assertThat(launch, is(not(nullValue())));
+        
+        launch.setAttribute(ATTRIBUTE_1, "value1");
+        launch.setAttribute(ATTRIBUTE_2, 5);
+        launch.setAttribute(ATTRIBUTE_3, true);
+        
+        var observableAttribute1 = adapter.createStringAttribute(ATTRIBUTE_1, "default");
+        var observableAttribute2 = adapter.createIntegerAttribute(ATTRIBUTE_2, 10);
+        var observableAttribute3 = adapter.createBooleanAttribute(ATTRIBUTE_3, false);
+        
+        // Test defaults
+        assertThat(observableAttribute1.getValue(), is(equalTo("default")));
+        assertThat(observableAttribute2.getValue(), is(equalTo(10)));
+        assertThat(observableAttribute3.getValue(), is(equalTo(false)));
+        
+        adapter.initializeFrom(launch);
+        
+        // Test initialize
+        assertThat(observableAttribute1.getValue(), is(equalTo("value1")));
+        assertThat(observableAttribute2.getValue(), is(equalTo(5)));
+        assertThat(observableAttribute3.getValue(), is(equalTo(true)));
+        
+        // Test write
+        observableAttribute1.setValue("value2");
+        adapter.performApply(launch);
+        assertThat(launch.getAttribute(ATTRIBUTE_1, ""), is(equalTo("value2")));
+    }
+
+}

--- a/tests/org.palladiosimulator.commons.ui.tests/src/org/palladiosimulator/commons/ui/launch/ObservableLaunchConfigurationTabTest.java
+++ b/tests/org.palladiosimulator.commons.ui.tests/src/org/palladiosimulator/commons/ui/launch/ObservableLaunchConfigurationTabTest.java
@@ -1,0 +1,109 @@
+package org.palladiosimulator.commons.ui.launch;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.palladiosimulator.commons.ui.launch.ObservableLaunchConfigurationAdapterTest.ATTRIBUTE_1;
+import static org.palladiosimulator.commons.ui.launch.ObservableLaunchConfigurationAdapterTest.ATTRIBUTE_2;
+import static org.palladiosimulator.commons.ui.launch.ObservableLaunchConfigurationAdapterTest.ATTRIBUTE_3;
+import static org.palladiosimulator.commons.ui.launch.ObservableLaunchConfigurationAdapterTest.ATTRIBUTE_4;
+import static org.palladiosimulator.commons.ui.launch.ObservableLaunchConfigurationAdapterTest.TEST_CONFIGURATION_TYPE;
+
+import org.eclipse.core.databinding.DataBindingContext;
+import org.eclipse.core.databinding.observable.value.IObservableValue;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunchConfigurationType;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import tools.mdsd.junit5utils.annotations.PluginTestOnly;
+
+@PluginTestOnly
+@ExtendWith(DefaultRealmExtension.class)
+class ObservableLaunchConfigurationTabTest extends AbstractDataBindingLaunchConfigurationTab {
+    IObservableValue<String> stringAttribute;
+    IObservableValue<Integer> intAttribute;
+    IObservableValue<Boolean> boolAttribute;
+    IObservableValue<URI> uriAttribute;
+    
+    ILaunchManager manager;
+    ILaunchConfigurationType launchType;
+    
+    @BeforeEach
+    void init() {
+        this.createControl(null);
+        
+        manager = DebugPlugin.getDefault().getLaunchManager();
+        launchType = manager.getLaunchConfigurationType(TEST_CONFIGURATION_TYPE);
+    }
+
+    @Test
+    void testSetDirty() throws CoreException {
+        var launch = launchType.newInstance(null, "testSetDirty");
+        assertThat(launch, is(not(nullValue())));
+        
+        launch.setAttribute(ATTRIBUTE_1, "value1");
+        
+        this.initializeFrom(launch);
+        assertThat(this.isDirty(), is(false));
+        
+        stringAttribute.setValue("value has changed");
+        
+        // The processing is usually done on the UI Thread of the Eclipse IDE
+        while (Display.getCurrent().readAndDispatch());
+        
+        assertThat(this.isDirty(), is(true));
+    }
+    
+    @Test
+    void testSetValues() throws CoreException {
+        var launch = launchType.newInstance(null, "testSetValues");
+        assertThat(launch, is(not(nullValue())));
+        
+        launch.setAttribute(ATTRIBUTE_1, "value1");
+        launch.setAttribute(ATTRIBUTE_2, 5);
+        launch.setAttribute(ATTRIBUTE_3, true);
+        
+        this.initializeFrom(launch);
+        
+        stringAttribute.setValue("newValue");
+        intAttribute.setValue(200);
+        boolAttribute.setValue(true);
+        uriAttribute.setValue(URI.createURI("file:///test.log"));
+        
+        this.performApply(launch);
+        assertThat(launch.getAttribute(ATTRIBUTE_1, ""), is(equalTo("newValue")));
+        assertThat(launch.getAttribute(ATTRIBUTE_2, 0), is(equalTo(200)));
+        assertThat(launch.getAttribute(ATTRIBUTE_3, false), is(equalTo(true)));
+        assertThat(launch.getAttribute(ATTRIBUTE_4, ""), is(equalTo("file:///test.log")));
+    }
+
+    @Override
+    public String getName() {
+        return "TestTab";
+    }
+
+    @Override
+    protected void registerDataBindings(ObservableLaunchConfigurationAttributeFactory attributeFactory,
+            DataBindingContext bindingContext) {
+        stringAttribute = attributeFactory.createStringAttribute(ATTRIBUTE_1, "");
+        intAttribute = attributeFactory.createIntegerAttribute(ATTRIBUTE_2, 2);
+        boolAttribute = attributeFactory.createBooleanAttribute(ATTRIBUTE_3, false);
+        uriAttribute = attributeFactory.createFromStringAttribute(ATTRIBUTE_4, 
+                URI.createURI("http://www.palladio-simulator.com"), URI::createURI, URI::toString);
+    }
+
+    @Override
+    protected void createControlInternal(Composite parent, DataBindingContext bindingContext) {
+        // Nothing to do here, as this in not actually a dialog.
+    }
+
+}


### PR DESCRIPTION
This PR adds a new bundle for for shared ui components and a common launch configuration tab base implementation, which facilitates the use of eclipse databindings.

A concrete implementation can be found [EDP2Tab](https://github.com/PalladioSimulator/Palladio-QuAL-RecorderFramework/blob/QUAL-47/bundles/org.palladiosimulator.recorderframework.edp2/src/org/palladiosimulator/recorderframework/edp2/launch/EDP2Tab.java).

Please merge instead of rebase, as there are follow up changes building ontop of this branch.