### PR TITLE
COMMONS-41 Proper handling of null strings in generic StoEx parser

### DIFF
--- a/bundles/org.palladiosimulator.commons.stoex/src/org/palladiosimulator/commons/stoex/api/impl/generic/GenericStoExParserImpl.java
+++ b/bundles/org.palladiosimulator.commons.stoex/src/org/palladiosimulator/commons/stoex/api/impl/generic/GenericStoExParserImpl.java
@@ -31,6 +31,9 @@ public abstract class GenericStoExParserImpl implements GenericStoExParser {
 
     @Override
     public Expression parse(String serializedStoEx) throws ParseException {
+        if (serializedStoEx == null || serializedStoEx.isBlank()) {
+            throw new ParseException("The given stoex is empty. Therefore it is no valid stoex.", 0);
+        }
         try (var sr = new StringReader(serializedStoEx)) {
             IParseResult result = parser.parse(sr);
             assertNoSyntaxErrorException(result);

--- a/tests/org.palladiosimulator.commons.stoex.tests/src/org/palladiosimulator/commons/stoex/tests/api/impl/generic/GenericStoExParserImplTest.java
+++ b/tests/org.palladiosimulator.commons.stoex.tests/src/org/palladiosimulator/commons/stoex/tests/api/impl/generic/GenericStoExParserImplTest.java
@@ -94,6 +94,16 @@ public class GenericStoExParserImplTest {
         // execution
         assertThrows(ParseException.class, () -> subject.parse(expectedParseInput));
     }
+    
+    @Test
+    public void testParseExceptionOnNull() {
+        assertThrows(ParseException.class, () -> subject.parse(null));
+    }
+    
+    @Test
+    public void testParseExceptionOnBlank() {
+        assertThrows(ParseException.class, () -> subject.parse(" \t "));
+    }
 
     protected INode mockSyntaxErrorNode(String errorMessage) {
         INode node = mock(INode.class);


### PR DESCRIPTION
Please refer to the [JIRA issue](https://palladio-simulator.atlassian.net/browse/COMMONS-41) for the rationale behind the changes.