### PR TITLE
Fix bug in randomization of identifiers via context menu

### DIFF
--- a/bundles/de.uka.ipd.sdq.identifier.uiutils/META-INF/MANIFEST.MF
+++ b/bundles/de.uka.ipd.sdq.identifier.uiutils/META-INF/MANIFEST.MF
@@ -9,5 +9,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.ui;bundle-version="3.118.100",
  org.eclipse.emf.edit;bundle-version="2.16.0",
  de.uka.ipd.sdq.identifier;bundle-version="5.1.0",
- org.eclipse.emf.transaction;bundle-version="1.9.1",
  org.eclipse.core.expressions;bundle-version="3.7.0"


### PR DESCRIPTION
## Bug
After randomizing the identifiers, the changes can be saved but all changes afterwards cannot be saved anymore and are lost.

## Solution
Avoid creating a transactional editing domain but use the existing editing domain.