### PR TITLE
Migrate to parent POM version 0.10.0

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -5,9 +5,4 @@
 		<artifactId>tycho-build</artifactId>
 		<version>2.7.5</version>
 	</extension>
-	<extension>
-		<groupId>org.palladiosimulator</groupId>
-		<artifactId>tycho-tp-refresh-maven-plugin</artifactId>
-		<version>0.2.6</version>
-	</extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.palladiosimulator</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.9.0</version>
+		<version>0.10.0</version>
 	</parent>
 	<groupId>org.palladiosimulator.core-commons</groupId>
 	<artifactId>parent</artifactId>	
@@ -14,7 +14,7 @@
 	<packaging>pom</packaging>
 	
 	<properties>
-		<org.palladiosimulator.maven.tychotprefresh.tplocation.2>${project.basedir}/releng/org.palladiosimulator.core-commons.targetplatform/tp.target</org.palladiosimulator.maven.tychotprefresh.tplocation.2>
+		<targetPlatform.relativePath>releng/org.palladiosimulator.core-commons.targetplatform/tp.target</targetPlatform.relativePath>
 	</properties>
 	
 	<modules>

--- a/releng/org.palladiosimulator.core-commons.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.core-commons.targetplatform/tp.target
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="org.palladiosimulator.core-commons Target Platform" sequenceNumber="1">
+<?pde version="3.8"?><target name="org.palladiosimulator.core-commons Target Platform" sequenceNumber="2">
 	<locations>
+		<location type="Target" uri="mvn:org.palladiosimulator:palladio-target-platforms:0.1.0:target:palladio-2023-03"/>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.mockito.junit-jupiter" version="0.0.0"/>
 			<unit id="org.mockito.mockito-core" version="0.0.0"/>
@@ -23,37 +24,20 @@
 			<unit id="org.apache.commons.lang3" version="0.0.0"/>
 			<repository location="https://download.eclipse.org/releases/2023-03/202303151000/"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release">
-			<unit id="tools.mdsd.library.standalone.initialization.core.feature.feature.group" version="0.0.0"/>
-			<repository location="https://updatesite.mdsd.tools/library-standaloneinitialization/releases/latest/"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="tools.mdsd.library.standalone.initialization.core.feature.feature.group" version="0.0.0"/>
 			<repository location="https://updatesite.mdsd.tools/library-standaloneinitialization/nightly/"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release">
-			<unit id="tools.mdsd.junit5utils.feature.feature.group" version="0.0.0"/>
-			<repository location="https://updatesite.mdsd.tools/library-junit5utils/releases/latest/"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="tools.mdsd.junit5utils.feature.feature.group" version="0.0.0"/>
 			<repository location="https://updatesite.mdsd.tools/library-junit5utils/nightly/"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release">
-			<unit id="tools.mdsd.ecoreworkflow.mwe2lib.xtext.feature.feature.group" version="0.0.0"/>
-			<unit id="tools.mdsd.ecoreworkflow.umlecoregenerator.feature.feature.group" version="0.0.0"/>
-			<repository location="https://updatesite.mdsd.tools/ecore-workflow/releases/latest/"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="tools.mdsd.ecoreworkflow.mwe2lib.xtext.feature.feature.group" version="0.0.0"/>
 			<unit id="tools.mdsd.ecoreworkflow.umlecoregenerator.feature.feature.group" version="0.0.0"/>
 			<repository location="https://updatesite.mdsd.tools/ecore-workflow/nightly/"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release">
-			<unit id="tools.mdsd.license.epl2.feature.group" version="0.0.0"/>
-			<repository location="https://updatesite.mdsd.tools/build-licensefeature/releases/latest/"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="tools.mdsd.license.epl2.feature.group" version="0.0.0"/>
 			<repository location="https://updatesite.mdsd.tools/build-licensefeature/nightly/"/>
 		</location>

--- a/releng/org.palladiosimulator.core-commons.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.core-commons.targetplatform/tp.target
@@ -1,65 +1,65 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?><target name="org.palladiosimulator.core-commons Target Platform" sequenceNumber="1">
-<locations>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-<unit id="org.mockito.junit-jupiter" version="0.0.0"/>
-<unit id="org.mockito.mockito-core" version="0.0.0"/>
-<unit id="net.bytebuddy.byte-buddy" version="0.0.0"/>
-<unit id="org.objenesis" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/orbit/downloads/2023-03/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-<unit id="org.apache.commons.math" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/orbit/downloads/2021-12/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-<unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-<unit id="org.hamcrest.core" version="0.0.0"/>
-<unit id="org.hamcrest.library" version="0.0.0"/>
-<unit id="org.objectweb.asm" version="0.0.0"/>
-<unit id="org.junit" version="0.0.0"/>
-<unit id="org.eclipse.e4.core.di" version="0.0.0"/>
-<unit id="org.apache.commons.lang3" version="0.0.0"/>
-<repository location="https://download.eclipse.org/releases/2023-03/202303151000/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release">
-<unit id="tools.mdsd.library.standalone.initialization.core.feature.feature.group" version="0.0.0"/>
-<repository location="https://updatesite.mdsd.tools/library-standaloneinitialization/releases/latest/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly">
-<unit id="tools.mdsd.library.standalone.initialization.core.feature.feature.group" version="0.0.0"/>
-<repository location="https://updatesite.mdsd.tools/library-standaloneinitialization/nightly/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release">
-<unit id="tools.mdsd.junit5utils.feature.feature.group" version="0.0.0"/>
-<repository location="https://updatesite.mdsd.tools/library-junit5utils/releases/latest/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly">
-<unit id="tools.mdsd.junit5utils.feature.feature.group" version="0.0.0"/>
-<repository location="https://updatesite.mdsd.tools/library-junit5utils/nightly/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release">
-<unit id="tools.mdsd.ecoreworkflow.mwe2lib.xtext.feature.feature.group" version="0.0.0"/>
-<unit id="tools.mdsd.ecoreworkflow.umlecoregenerator.feature.feature.group" version="0.0.0"/>
-<repository location="https://updatesite.mdsd.tools/ecore-workflow/releases/latest/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly">
-<unit id="tools.mdsd.ecoreworkflow.mwe2lib.xtext.feature.feature.group" version="0.0.0"/>
-<unit id="tools.mdsd.ecoreworkflow.umlecoregenerator.feature.feature.group" version="0.0.0"/>
-<repository location="https://updatesite.mdsd.tools/ecore-workflow/nightly/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release">
-<unit id="tools.mdsd.license.epl2.feature.group" version="0.0.0"/>
-<repository location="https://updatesite.mdsd.tools/build-licensefeature/releases/latest/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly">
-<unit id="tools.mdsd.license.epl2.feature.group" version="0.0.0"/>
-<repository location="https://updatesite.mdsd.tools/build-licensefeature/nightly/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-<unit id="de.itemis.xtext.antlr.feature.feature.group" version="0.0.0"/>
-<repository location="http://download.itemis.com/updates/releases/2.1.1"/>
-</location>
-</locations>
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<unit id="org.mockito.junit-jupiter" version="0.0.0"/>
+			<unit id="org.mockito.mockito-core" version="0.0.0"/>
+			<unit id="net.bytebuddy.byte-buddy" version="0.0.0"/>
+			<unit id="org.objenesis" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2023-03/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<unit id="org.apache.commons.math" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2021-12/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.hamcrest.core" version="0.0.0"/>
+			<unit id="org.hamcrest.library" version="0.0.0"/>
+			<unit id="org.objectweb.asm" version="0.0.0"/>
+			<unit id="org.junit" version="0.0.0"/>
+			<unit id="org.eclipse.e4.core.di" version="0.0.0"/>
+			<unit id="org.apache.commons.lang3" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/releases/2023-03/202303151000/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release">
+			<unit id="tools.mdsd.library.standalone.initialization.core.feature.feature.group" version="0.0.0"/>
+			<repository location="https://updatesite.mdsd.tools/library-standaloneinitialization/releases/latest/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly">
+			<unit id="tools.mdsd.library.standalone.initialization.core.feature.feature.group" version="0.0.0"/>
+			<repository location="https://updatesite.mdsd.tools/library-standaloneinitialization/nightly/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release">
+			<unit id="tools.mdsd.junit5utils.feature.feature.group" version="0.0.0"/>
+			<repository location="https://updatesite.mdsd.tools/library-junit5utils/releases/latest/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly">
+			<unit id="tools.mdsd.junit5utils.feature.feature.group" version="0.0.0"/>
+			<repository location="https://updatesite.mdsd.tools/library-junit5utils/nightly/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release">
+			<unit id="tools.mdsd.ecoreworkflow.mwe2lib.xtext.feature.feature.group" version="0.0.0"/>
+			<unit id="tools.mdsd.ecoreworkflow.umlecoregenerator.feature.feature.group" version="0.0.0"/>
+			<repository location="https://updatesite.mdsd.tools/ecore-workflow/releases/latest/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly">
+			<unit id="tools.mdsd.ecoreworkflow.mwe2lib.xtext.feature.feature.group" version="0.0.0"/>
+			<unit id="tools.mdsd.ecoreworkflow.umlecoregenerator.feature.feature.group" version="0.0.0"/>
+			<repository location="https://updatesite.mdsd.tools/ecore-workflow/nightly/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release">
+			<unit id="tools.mdsd.license.epl2.feature.group" version="0.0.0"/>
+			<repository location="https://updatesite.mdsd.tools/build-licensefeature/releases/latest/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly">
+			<unit id="tools.mdsd.license.epl2.feature.group" version="0.0.0"/>
+			<repository location="https://updatesite.mdsd.tools/build-licensefeature/nightly/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<unit id="de.itemis.xtext.antlr.feature.feature.group" version="0.0.0"/>
+			<repository location="http://download.itemis.com/updates/releases/2.1.1"/>
+		</location>
+	</locations>
 </target>


### PR DESCRIPTION
### Overview
- Migrate from parent POM version `0.9.0` to the new parent POM version `0.10.0`
- Locally verified build success

### Changes
- In `pom.xml`:
  - Parent POM updated from `0.9.0` to `0.10.0`  
  - Renamed property `org.palladiosimulator.maven.tychotprefresh.tplocation.2` to `targetPlatform.relativePath` and trimmed its path value to start at `releng`  
- In `.mvn/extensions.xml`:
  - Removed `<extension>` block for `org.palladiosimulator:tycho-tp-refresh-maven-plugin`  
- In the target platform `tp.target`:
  - Inserted new `<location>` with URI `mvn:org.palladiosimulator:palladio-target-platforms:0.1.0:target:palladio-2023-03`, since the Palladio target platform is now decoupled from the parent POM  
  - Unified all `includeSource` attributes by setting them to `false`, as the value must be the same across all locations to prevent resolution failure  
  - Removed specifics of the `tycho-tp-refresh-maven-plugin` to be standard-compliant:  
    - Removed any `<location filter="release">` entries  
    - Removed `filter="nightly"` attributes  
    - Removed all `refresh="true"` attributes and, where present, set each `<unit>`’s `version` attribute to `0.0.0`  
  - Added indentation to improve readability