### PR TITLE
Migrate to parent POM version 0.11.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ jobs:
     with:
       use-display-output: true
       no-caching: true
+      runner-label: self-hosted
       deploy-updatesite: 'releng/org.palladiosimulator.core-commons.updatesite/target/repository'
     secrets:
       SERVER_SSH_KEY: ${{ secrets.DEPLOYMENT_SERVER_SSH_KEY }}

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
 	<extension>
 		<groupId>org.eclipse.tycho</groupId>
 		<artifactId>tycho-build</artifactId>
-		<version>2.7.5</version>
+		<version>4.0.13</version>
 	</extension>
 </extensions>

--- a/bundles/de.uka.ipd.sdq.identifier/model/identifier.genmodel
+++ b/bundles/de.uka.ipd.sdq.identifier/model/identifier.genmodel
@@ -3,7 +3,7 @@
     xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" modelDirectory="/de.uka.ipd.sdq.identifier/src" modelPluginID="de.uka.ipd.sdq.identifier"
     modelName="Identifier" rootExtendsInterface="org.eclipse.emf.cdo.CDOObject" rootExtendsClass="org.eclipse.emf.internal.cdo.CDOObjectImpl"
     rootImplementsInterface="" importerID="org.eclipse.emf.importer.ecore" featureDelegation="Dynamic"
-    complianceLevel="6.0" copyrightFields="false" importOrganizing="true">
+    complianceLevel="17.0" copyrightFields="false" importOrganizing="true">
   <foreignModel>identifier.ecore</foreignModel>
   <modelPluginVariables>CDO=org.eclipse.emf.cdo</modelPluginVariables>
   <genPackages prefix="Identifier" basePackage="de.uka.ipd.sdq" resource="XML" disposableProviderFactory="true"

--- a/bundles/de.uka.ipd.sdq.probfunction/model/ProbabilityFunction.genmodel
+++ b/bundles/de.uka.ipd.sdq.probfunction/model/ProbabilityFunction.genmodel
@@ -4,7 +4,7 @@
     copyrightText="Copyright 2007-2017, Palladiosimulator.org" modelDirectory="/de.uka.ipd.sdq.probfunction/src"
     modelPluginID="de.uka.ipd.sdq.probfunction" modelName="ProbabilityFunction" rootExtendsInterface="org.eclipse.emf.cdo.CDOObject"
     rootExtendsClass="org.eclipse.emf.internal.cdo.CDOObjectImpl" codeFormatting="true"
-    importerID="org.eclipse.emf.importer.ecore" featureDelegation="Dynamic" complianceLevel="7.0"
+    importerID="org.eclipse.emf.importer.ecore" featureDelegation="Dynamic" complianceLevel="17.0"
     language="en" usedGenPackages="../../org.eclipse.emf.ecore/model/Ecore.genmodel#//ecore ../../de.uka.ipd.sdq.units/model/Units.genmodel#//units"
     cleanup="true">
   <genAnnotations source="http://www.eclipse.org/emf/2002/GenModel/importer/org.eclipse.uml2.uml.ecore.importer">

--- a/bundles/de.uka.ipd.sdq.stoex.edit/META-INF/MANIFEST.MF
+++ b/bundles/de.uka.ipd.sdq.stoex.edit/META-INF/MANIFEST.MF
@@ -20,4 +20,4 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore.edit;visibility:=reexport,
  org.eclipse.uml2.common.edit;visibility:=reexport
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/bundles/de.uka.ipd.sdq.stoex/META-INF/MANIFEST.MF
+++ b/bundles/de.uka.ipd.sdq.stoex/META-INF/MANIFEST.MF
@@ -26,5 +26,5 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ocl.ecore;visibility:=reexport,
  org.palladiosimulator.core-commons.mwe2;resolution:=optional
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: de.uka.ipd.sdq.stoex

--- a/bundles/de.uka.ipd.sdq.stoex/model/stoex.genmodel
+++ b/bundles/de.uka.ipd.sdq.stoex/model/stoex.genmodel
@@ -5,7 +5,7 @@
     editDirectory="/de.uka.ipd.sdq.stoex.edit/src-gen" editorDirectory="/de.uka.ipd.sdq.stoex.editor/src-gen"
     modelPluginID="de.uka.ipd.sdq.stoex" modelName="Stoex" rootExtendsInterface="org.eclipse.emf.cdo.CDOObject"
     rootExtendsClass="org.eclipse.emf.internal.cdo.CDOObjectImpl" codeFormatting="true"
-    importerID="org.eclipse.emf.importer.ecore" featureDelegation="Dynamic" complianceLevel="6.0"
+    importerID="org.eclipse.emf.importer.ecore" featureDelegation="Dynamic" complianceLevel="17.0"
     language="en" usedGenPackages="../../de.uka.ipd.sdq.probfunction/model/ProbabilityFunction.genmodel#//probfunction ../../de.uka.ipd.sdq.units/model/Units.genmodel#//units"
     cleanup="true">
   <genAnnotations source="http://www.eclipse.org/emf/2002/GenModel/importer/org.eclipse.uml2.uml.ecore.importer">

--- a/bundles/de.uka.ipd.sdq.units/model/Units.genmodel
+++ b/bundles/de.uka.ipd.sdq.units/model/Units.genmodel
@@ -4,7 +4,7 @@
     copyrightText="Copyright 2007-2017, Palladiosimulator.org" modelDirectory="/de.uka.ipd.sdq.units/src"
     modelPluginID="de.uka.ipd.sdq.units" modelName="Units" rootExtendsInterface="org.eclipse.emf.cdo.CDOObject"
     rootExtendsClass="org.eclipse.emf.internal.cdo.CDOObjectImpl" codeFormatting="true"
-    importerID="org.eclipse.emf.importer.ecore" featureDelegation="Dynamic" complianceLevel="7.0"
+    importerID="org.eclipse.emf.importer.ecore" featureDelegation="Dynamic" complianceLevel="17.0"
     language="en" usedGenPackages="../../org.eclipse.emf.ecore/model/Ecore.genmodel#//ecore"
     cleanup="true">
   <genAnnotations source="http://www.eclipse.org/emf/2002/GenModel/importer/org.eclipse.uml2.uml.ecore.importer">

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
 		<groupId>org.palladiosimulator</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
 		<version>0.10.1</version>
+		<relativePath/>
 	</parent>
 	<groupId>org.palladiosimulator.core-commons</groupId>
 	<artifactId>parent</artifactId>	

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.palladiosimulator</groupId>
-		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.10.1</version>
+		<artifactId>repository-parent</artifactId>
+		<version>0.11.0</version>
 		<relativePath/>
 	</parent>
 	<groupId>org.palladiosimulator.core-commons</groupId>

--- a/releng/org.palladiosimulator.core-commons.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.core-commons.targetplatform/tp.target
@@ -43,7 +43,7 @@
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="de.itemis.xtext.antlr.feature.feature.group" version="0.0.0"/>
-			<repository location="http://download.itemis.com/updates/releases/2.1.1"/>
+			<repository location="https://artifacts.itemis.cloud/repository/p2/xtext-updates/releases/2.1.1"/>
 		</location>
 	</locations>
 </target>

--- a/tests/de.uka.ipd.sdq.identifier.uiutils.tests/model/identifiertest.genmodel
+++ b/tests/de.uka.ipd.sdq.identifier.uiutils.tests/model/identifiertest.genmodel
@@ -4,7 +4,7 @@
     modelPluginID="de.uka.ipd.sdq.identifier.editor.tests" modelName="Identifiertest"
     rootExtendsInterface="org.eclipse.emf.cdo.CDOObject" rootExtendsClass="org.eclipse.emf.internal.cdo.CDOObjectImpl"
     reflectiveDelegation="true" importerID="org.eclipse.emf.importer.cdo" featureDelegation="Reflective"
-    complianceLevel="5.0" copyrightFields="false" providerRootExtendsClass="org.eclipse.emf.cdo.edit.CDOItemProviderAdapter"
+    complianceLevel="17.0" copyrightFields="false" providerRootExtendsClass="org.eclipse.emf.cdo.edit.CDOItemProviderAdapter"
     usedGenPackages="../../de.uka.ipd.sdq.identifier/model/identifier.genmodel#//identifier"
     importOrganizing="true">
   <foreignModel>identifiertest.ecore</foreignModel>


### PR DESCRIPTION
- Add empty `<relativePath/>` to the parent POM to avoid Maven warnings about mismatched parent resolution.
- Update Tycho version in `.mvn/extensions.xml` to `4.0.13`.
- Update Itemis Xtext repository location in `tp.target` from `http://download.itemis.com/updates/releases/2.1.1` to `https://artifacts.itemis.cloud/repository/p2/xtext-updates/releases/2.1.1`.
- Set `Bundle-RequiredExecutionEnvironment` to `JavaSE-17` in MANIFEST.MF files.
- Set `complianceLevel` to `17.0` in `.genmodel` files.
- Migrate from parent POM `eclipse-parent-updatesite` version `0.10.1` to `repository-parent` version `0.11.0`.